### PR TITLE
update old GCCcore easyconfigs to use SHA256 checksums

### DIFF
--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-5.3.0.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-5.3.0.eb
@@ -21,7 +21,6 @@ source_urls = [
     'https://libisl.sourceforge.io/',  # fallback URL for isl
     'http://isl.gforge.inria.fr/',  # original HTTP source for ISL
 ]
-
 sources = [
     'gcc-%(version)s.tar.bz2',
     'gmp-6.1.0.tar.bz2',
@@ -29,22 +28,21 @@ sources = [
     'mpc-1.0.3.tar.gz',
     'isl-0.15.tar.bz2',
 ]
-
 patches = [('mpfr-%s-allpatches-20151029.patch' % local_mpfr_version, '../mpfr-%s' % local_mpfr_version)]
+checksums = [
+    'b84f5592e9218b73dbae612b5253035a7b34a9a1f7688d2e1bfaaf7267d5c4db',  # gcc-5.3.0.tar.bz2
+    '498449a994efeba527885c10405993427995d3f86b8768d8cdf8d9dd7c6b73e8',  # gmp-6.1.0.tar.bz2
+    'b87feae279e6da95a0b45eabdb04f3a35422dab0d30113d58a7803c0d73a79dc',  # mpfr-3.1.3.tar.gz
+    '617decc6ea09889fb08ede330917a00b16809b8db88c29c31bfbb49cbf88ecc3',  # mpc-1.0.3.tar.gz
+    '8ceebbf4d9a81afa2b4449113cee4b7cb14a687d7a549a963deb5e2a41458b6b',  # isl-0.15.tar.bz2
+    'ccbe4044c12db40d9f85ae5fd2ed443a3b19b95c86ebef05c82f41509cf6d1b4',  # mpfr-3.1.3-allpatches-20151029.patch
+]
 
 builddependencies = [
     ('binutils', '2.26'),
     ('M4', '1.4.17'),
 ]
 
-checksums = [
-    'c9616fd448f980259c31de613e575719',     # gcc-5.3.0.tar.bz2
-    '86ee6e54ebfc4a90b643a65e402c4048',     # gmp-6.1.0.tar.bz2
-    '7b650781f0a7c4a62e9bc8bdaaa0018b',     # mpfr-3.1.3.tar.gz
-    'd6a1d5f8ddea3abd2cc3e98f58352d26',     # mpc-1.0.3.tar.gz
-    '8428efbbc6f6e2810ce5c1ba73ecf98c',     # isl-0.15.tar.bz2
-    '6476b450c3db177b2250f3549362380e',     # mpfr-3.1.3-allpatches-20151029.patch
-]
 
 languages = ['c', 'c++', 'fortran']
 

--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-5.4.0.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-5.4.0.eb
@@ -21,7 +21,6 @@ source_urls = [
     'https://libisl.sourceforge.io/',  # fallback URL for isl
     'http://isl.gforge.inria.fr/',  # original HTTP source for ISL
 ]
-
 sources = [
     'gcc-%(version)s.tar.bz2',
     'gmp-6.1.0.tar.bz2',
@@ -29,22 +28,21 @@ sources = [
     'mpc-1.0.3.tar.gz',
     'isl-0.15.tar.bz2',
 ]
-
 patches = [('mpfr-%s-allpatches-20160601.patch' % local_mpfr_version, '../mpfr-%s' % local_mpfr_version)]
+checksums = [
+    '608df76dec2d34de6558249d8af4cbee21eceddbcb580d666f7a5a583ca3303a',  # gcc-5.4.0.tar.bz2
+    '498449a994efeba527885c10405993427995d3f86b8768d8cdf8d9dd7c6b73e8',  # gmp-6.1.0.tar.bz2
+    '0d4de7e1476f79d24c38d5bc04a06fcc9a1bb9cf35fd654ceada29af03ad1844',  # mpfr-3.1.4.tar.gz
+    '617decc6ea09889fb08ede330917a00b16809b8db88c29c31bfbb49cbf88ecc3',  # mpc-1.0.3.tar.gz
+    '8ceebbf4d9a81afa2b4449113cee4b7cb14a687d7a549a963deb5e2a41458b6b',  # isl-0.15.tar.bz2
+    '73816930b9d1324127e41096f0c82ba9a1e82502c3c8e7ed82915d9cbb1a1e40',  # mpfr-3.1.4-allpatches-20160601.patch
+]
 
 builddependencies = [
     ('binutils', '2.26'),
     ('M4', '1.4.17'),
 ]
 
-checksums = [
-    '4c626ac2a83ef30dfb9260e6f59c2b30',     # gcc-5.4.0.tar.bz2
-    '86ee6e54ebfc4a90b643a65e402c4048',     # gmp-6.1.0.tar.bz2
-    '482ab3c120ffc959f631b4ba9ec59a46',     # mpfr-3.1.4.tar.gz
-    'd6a1d5f8ddea3abd2cc3e98f58352d26',     # mpc-1.0.3.tar.gz
-    '8428efbbc6f6e2810ce5c1ba73ecf98c',     # isl-0.15.tar.bz2
-    '22164533561142b70fda09af4e775acc',     # mpfr-3.1.4-allpatches-20150603.patch
-]
 
 languages = ['c', 'c++', 'fortran']
 

--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-6.1.0.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-6.1.0.eb
@@ -22,7 +22,6 @@ source_urls = [
     'https://libisl.sourceforge.io/',  # fallback URL for isl
     'http://isl.gforge.inria.fr/',  # original HTTP source for ISL
 ]
-
 sources = [
     'gcc-%(version)s.tar.bz2',
     'gmp-6.1.1.tar.bz2',
@@ -30,24 +29,25 @@ sources = [
     'mpc-1.0.3.tar.gz',
     'isl-0.16.1.tar.bz2',
 ]
-
-builddependencies = [
-    ('M4', '1.4.17'),
-    ('binutils', '2.27'),
-]
-
 patches = [
     ('mpfr-%s-allpatches-20160804.patch' % local_mpfr_version, '../mpfr-%s' % local_mpfr_version),
     ('%s-%s_fix-find-isl.patch' % (name, version)),
     'GCCcore-6.x-fix-ubsan.patch',
 ]
-
 checksums = [
-    '8fb6cb98b8459f5863328380fbf06bd1',     # gcc-6.1.0.tar.bz2
-    '4c175f86e11eb32d8bf9872ca3a8e11d',     # gmp-6.1.1.tar.bz2
-    'b8a2f6b0e68bef46e53da2ac439e1cf4',     # mpfr-3.1.4.tar.gz
-    'd6a1d5f8ddea3abd2cc3e98f58352d26',     # mpc-1.0.3.tar.gz
-    'ac1f25a0677912952718a51f5bc20f32',     # isl-0.16.1.tar.bz2
+    '09c4c85cabebb971b1de732a0219609f93fc0af5f86f6e437fd8d7f832f1a351',  # gcc-6.1.0.tar.bz2
+    'a8109865f2893f1373b0a8ed5ff7429de8db696fc451b1036bd7bdf95bbeffd6',  # gmp-6.1.1.tar.bz2
+    'd3103a80cdad2407ed581f3618c4bed04e0c92d1cf771a65ead662cc397f7775',  # mpfr-3.1.4.tar.bz2
+    '617decc6ea09889fb08ede330917a00b16809b8db88c29c31bfbb49cbf88ecc3',  # mpc-1.0.3.tar.gz
+    '412538bb65c799ac98e17e8cfcdacbb257a57362acfaaff254b0fcae970126d2',  # isl-0.16.1.tar.bz2
+    '919e0de301f557fc3be8db7652d611adcd339b450994b990b47f6c49d9fac181',  # mpfr-3.1.4-allpatches-20160804.patch
+    '5ad909606d17d851c6ad629b4fddb6c1621844218b8d139fed18c502a7696c68',  # GCCcore-6.1.0_fix-find-isl.patch
+    'a021bdc9da72438475168639d71dcbd8953becef8230eabd46bc5719519c164e',  # GCCcore-6.x-fix-ubsan.patch
+]
+
+builddependencies = [
+    ('M4', '1.4.17'),
+    ('binutils', '2.27'),
 ]
 
 languages = ['c', 'c++', 'fortran']

--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-6.2.0.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-6.2.0.eb
@@ -21,7 +21,6 @@ source_urls = [
     'https://libisl.sourceforge.io/',  # fallback URL for isl
     'http://isl.gforge.inria.fr/',  # original HTTP source for ISL
 ]
-
 sources = [
     'gcc-%(version)s.tar.bz2',
     'gmp-6.1.1.tar.bz2',
@@ -29,24 +28,25 @@ sources = [
     'mpc-1.0.3.tar.gz',
     'isl-0.16.1.tar.bz2',
 ]
-
-builddependencies = [
-    ('M4', '1.4.17'),
-    ('binutils', '2.27'),
-]
-
 patches = [
     ('mpfr-%s-allpatches-20160804.patch' % local_mpfr_version, '../mpfr-%s' % local_mpfr_version),
     '%(name)s-%(version)s-fix-find-isl.patch',
     'GCCcore-6.x-fix-ubsan.patch',
 ]
-
 checksums = [
-    '9768625159663b300ae4de2f4745fcc4',     # gcc-6.2.0.tar.bz2
-    '4c175f86e11eb32d8bf9872ca3a8e11d',     # gmp-6.1.1.tar.bz2
-    'b8a2f6b0e68bef46e53da2ac439e1cf4',     # mpfr-3.1.4.tar.gz
-    'd6a1d5f8ddea3abd2cc3e98f58352d26',     # mpc-1.0.3.tar.gz
-    'ac1f25a0677912952718a51f5bc20f32',     # isl-0.16.1.tar.bz2
+    '9944589fc722d3e66308c0ce5257788ebd7872982a718aa2516123940671b7c5',  # gcc-6.2.0.tar.bz2
+    'a8109865f2893f1373b0a8ed5ff7429de8db696fc451b1036bd7bdf95bbeffd6',  # gmp-6.1.1.tar.bz2
+    'd3103a80cdad2407ed581f3618c4bed04e0c92d1cf771a65ead662cc397f7775',  # mpfr-3.1.4.tar.bz2
+    '617decc6ea09889fb08ede330917a00b16809b8db88c29c31bfbb49cbf88ecc3',  # mpc-1.0.3.tar.gz
+    '412538bb65c799ac98e17e8cfcdacbb257a57362acfaaff254b0fcae970126d2',  # isl-0.16.1.tar.bz2
+    '919e0de301f557fc3be8db7652d611adcd339b450994b990b47f6c49d9fac181',  # mpfr-3.1.4-allpatches-20160804.patch
+    '5ad909606d17d851c6ad629b4fddb6c1621844218b8d139fed18c502a7696c68',  # GCCcore-6.2.0-fix-find-isl.patch
+    'a021bdc9da72438475168639d71dcbd8953becef8230eabd46bc5719519c164e',  # GCCcore-6.x-fix-ubsan.patch
+]
+
+builddependencies = [
+    ('M4', '1.4.17'),
+    ('binutils', '2.27'),
 ]
 
 languages = ['c', 'c++', 'fortran']

--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-7.1.0.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-7.1.0.eb
@@ -21,7 +21,6 @@ source_urls = [
     'https://libisl.sourceforge.io/',  # fallback URL for isl
     'http://isl.gforge.inria.fr/',  # original HTTP source for ISL
 ]
-
 sources = [
     'gcc-%(version)s.tar.bz2',
     'gmp-6.1.2.tar.bz2',
@@ -29,23 +28,23 @@ sources = [
     'mpc-1.0.3.tar.gz',
     'isl-0.16.1.tar.bz2',
 ]
-
-builddependencies = [
-    ('M4', '1.4.18'),
-    ('binutils', '2.28'),
-]
-
 patches = [
     ('mpfr-%s-allpatches-20161219.patch' % local_mpfr_version, '../mpfr-%s' % local_mpfr_version),
     'GCCcore-6.2.0-fix-find-isl.patch',
 ]
-
 checksums = [
-    '6bf56a2bca9dac9dbbf8e8d1036964a8',     # gcc-7.1.0.tar.bz2
-    '8ddbb26dc3bd4e2302984debba1406a5',     # gmp-6.1.2.tar.bz2
-    'b1d23a55588e3b2a13e3be66bc69fd8d',     # mpfr-3.1.5.tar.gz
-    'd6a1d5f8ddea3abd2cc3e98f58352d26',     # mpc-1.0.3.tar.gz
-    'ac1f25a0677912952718a51f5bc20f32',     # isl-0.16.1.tar.bz2
+    '8a8136c235f64c6fef69cac0d73a46a1a09bb250776a050aec8f9fc880bebc17',  # gcc-7.1.0.tar.bz2
+    '5275bb04f4863a13516b2f39392ac5e272f5e1bb8057b18aec1c9b79d73d8fb2',  # gmp-6.1.2.tar.bz2
+    'ca498c1c7a74dd37a576f353312d1e68d490978de4395fa28f1cbd46a364e658',  # mpfr-3.1.5.tar.bz2
+    '617decc6ea09889fb08ede330917a00b16809b8db88c29c31bfbb49cbf88ecc3',  # mpc-1.0.3.tar.gz
+    '412538bb65c799ac98e17e8cfcdacbb257a57362acfaaff254b0fcae970126d2',  # isl-0.16.1.tar.bz2
+    '223001d1ef6e9a2c8275eb66c07670d2ea378a0b0082c60857ecc273d0ee44b7',  # mpfr-3.1.5-allpatches-20161219.patch
+    '5ad909606d17d851c6ad629b4fddb6c1621844218b8d139fed18c502a7696c68',  # GCCcore-6.2.0-fix-find-isl.patch
+]
+
+builddependencies = [
+    ('M4', '1.4.18'),
+    ('binutils', '2.28'),
 ]
 
 languages = ['c', 'c++', 'fortran']


### PR DESCRIPTION
@SebastianAchilles In order for the tests to pass in https://github.com/easybuilders/easybuild-easyconfigs/pull/15320, we need to update to SHA256 checksums in the older GCCcore easyconfigs.